### PR TITLE
Fix readthedocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Below are screenshots of typical states that you would see in everyday use.
 
 ## Documentation
 
-[![Documentation Status](https://readthedocs.org/projects/liquidprompt-powerline/badge/?version=stable)](https://liquidprompt-powerline.readthedocs.io/)
+[![Documentation Status](https://readthedocs.org/projects/liquid-prompt-powerline/badge/?version=stable)](https://liquid-prompt-powerline.readthedocs.io/)
 
 See the [Liquid Prompt documentation](https://liquidprompt.readthedocs.io/) for
 details on installing and configuring Liquidprompt.
 
-See the [Liquid Prompt Powerline documentation](https://liquidprompt-powerline.readthedocs.io/) for
+See the [Liquid Prompt Powerline documentation](https://liquid-prompt-powerline.readthedocs.io/) for
 details on installing this theme.
 
 


### PR DESCRIPTION
The links in the `README.md` pointed to a non existing readthedocs project (`liquidprompt-powerline`). They now point to `liquid-prompt-powerline`.

Another option could be to rename the `readthedocs` project to match the GitHub project name. But this needs to be decided by the maintainer. ;)